### PR TITLE
feat: 治療師註冊流程重構與 API/Schema 優化

### DIFF
--- a/docs/FrontendTherapistRegistrationGuide.md
+++ b/docs/FrontendTherapistRegistrationGuide.md
@@ -1,0 +1,93 @@
+# 寫給前端的語言治療師註冊流程說明書
+
+本文件旨在向前端開發者說明新的、簡化後的語言治療師註冊流程。此流程將使用者基本資料與治療師專業檔案的提交合併為單一步驟，並簡化了文件上傳的驗證機制。
+
+## 流程步驟
+
+### 1. 註冊新治療師帳號 (Register New Therapist Account)
+
+這是治療師註冊流程的第一步，也是唯一需要前端提交所有註冊資訊的 API。
+
+*   **端點 (Endpoint):** `POST /therapist/register`
+*   **請求方法 (Method):** `POST`
+*   **請求主體 (Request Body):** `application/json`
+    *   請使用 `TherapistRegisterRequest` Schema。此 Schema 包含了使用者基本資料和治療師專業檔案的所有欄位。
+    *   **欄位說明:**
+        *   `email` (string, EmailStr): 使用者電子郵件，必須是有效格式。
+        *   `password` (string): 密碼，至少8個字元，需包含大小寫字母、數字和特殊字元。
+        *   `name` (string): 使用者姓名。
+        *   `gender` (enum: "male", "female", "other"): 使用者性別。
+        *   `age` (integer): 使用者年齡。
+        *   `license_number` (string): 治療師執照號碼，**必填且唯一**。
+        *   `specialization` (string, optional): 專長領域。
+        *   `bio` (string, optional): 個人簡介。
+        *   `years_experience` (integer, optional): 執業年資。
+        *   `education` (string, optional): 學歷。
+    *   **範例請求 (Example Request):**
+        ```json
+        {
+          "email": "therapist.new.example@example.com",
+          "password": "SecurePassword123!",
+          "name": "王小明",
+          "gender": "male",
+          "age": 30,
+          "license_number": "TH987654",
+          "specialization": "兒童語言發展",
+          "bio": "專精於兒童語言發展治療，具有豐富的臨床經驗。",
+          "years_experience": 5,
+          "education": "國立陽明交通大學語言治療學系碩士"
+        }
+        ```
+*   **回應主體 (Response Body):** `application/json`
+    *   請使用 `TherapistRegistrationResponse` Schema。
+    *   **欄位說明:**
+        *   `user_id` (UUID): 新建立的使用者唯一識別碼。
+        *   `verification_application_id` (UUID): 關聯到此註冊的驗證申請唯一識別碼。
+    *   **範例回應 (Example Response):**
+        ```json
+        {
+          "user_id": "550e8400-e29b-41d4-a716-446655440001",
+          "verification_application_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+        }
+        ```
+*   **重要提示:**
+    *   此 API 呼叫會一次性完成使用者帳號建立、治療師個人檔案建立，以及一個待處理的驗證申請。
+    *   使用者帳號的初始角色為 `CLIENT`，並在驗證申請通過後才會被提升為 `THERAPIST`。
+    *   此步驟完成後，前端應引導使用者進入文件上傳流程。
+
+### 2. 上傳驗證文件 (Upload Verification Documents)
+
+在完成註冊後，前端應提示使用者上傳必要的驗證文件。
+
+*   **端點 (Endpoint):** `POST /verification/therapist-applications/{application_id}/documents/`
+*   **請求方法 (Method):** `POST`
+*   **路徑參數 (Path Parameter):**
+    *   `application_id` (UUID): 從步驟 1 的回應中取得的 `verification_application_id`。
+*   **請求主體 (Request Body):** `multipart/form-data`
+    *   **表單欄位 (Form Fields):**
+        *   `document_type` (string, enum): 文件的類型。目前支援的類型包括：
+            *   `therapist_certificate` (治療師證書)
+            *   `id_card_front` (身份證正面)
+            *   `id_card_back` (身份證反面)
+        *   `file` (file): 要上傳的檔案。
+    *   **範例 `curl` 指令 (Example `curl` command):**
+        ```bash
+        curl -X POST "http://your-backend-url/verification/therapist-applications/YOUR_APPLICATION_ID/documents/" \
+          -H "Content-Type: multipart/form-data" \
+          -F "document_type=therapist_certificate" \
+          -F "file=@/path/to/your/certificate.pdf"
+        ```
+        *請將 `YOUR_APPLICATION_ID` 替換為實際的 `verification_application_id`。*
+        *請將 `/path/to/your/certificate.pdf` 替換為您要上傳的檔案路徑。*
+*   **驗證 (Authentication):** **此 API 無須進行登入 (不需要 JWT Token)。** 前端可以直接呼叫此端點。
+*   **重要提示:**
+    *   文件上傳後，後端會將檔案儲存到 MinIO (S3 相容儲存)。
+    *   每次上傳文件，相關的驗證申請狀態會被重置為 `PENDING` (待處理)，等待管理員審核。
+    *   前端應引導使用者上傳所有必要的文件類型。
+
+### 後續流程
+
+1.  **管理員審核:** 使用者上傳所有文件後，系統管理員將會審核這些文件。
+2.  **狀態更新:** 審核通過後，系統會自動將使用者的帳號狀態更新為「已驗證」，並將其角色提升為 `THERAPIST`。
+3.  **通知:** 使用者將會收到審核結果的通知。
+4.  **前端處理:** 前端可以根據 `verification_application_id` 查詢驗證申請的狀態 (`GET /verification/therapist-applications/me` 或管理員介面)，並向使用者顯示「待審核」或「已通過」等訊息。

--- a/docs/NewTherapistRegister.md
+++ b/docs/NewTherapistRegister.md
@@ -1,0 +1,37 @@
+本文件重點放在調整語言治療師的註冊流程
+# 語言治療師註冊流程調整
+## 步驟
+1. 在一般的註冊表單中使用 /therapist/register API 註冊新治療師，欄位包括：
+```json
+{
+  // 使用者基本資料
+  "email": "user@example.com",
+  "password": "stringst",
+  "name": "string",
+  "gender": "male",
+  "age": 150,
+  // 語言治療師個人資料
+  "bio": "專精於兒童語言發展治療，具有豐富的臨床經驗。",
+  "education": "國立陽明交通大學語言治療學系碩士",
+  "license_number": "TH123456",
+  "specialization": "語言治療",
+  "years_experience": 5
+}
+```
+Response 內容請再寫一個 Schema，包含 user_id、therapist_profile_id、verification_application_id
+```json
+{
+  "user_id": "550e8400-e29b-41d4-a716-446655440001",
+  "verification_application_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+}
+```
+（想讓目前複雜的治療師註冊流程變得更加簡單）
+2. 使用者註冊後，前端會自動導向到治療師資料上傳頁面，並顯示以下訊息：
+```
+請上傳您的治療師證照和相關文件以完成註冊。
+我們將在收到您的文件後進行審核，審核通過後
+您將收到通知。
+```
+3. 使用者上傳證照和相關文件後，前端會呼叫 /verification/therapist-applications/{application_id}/documents/ API，本 API 無須進行登入，只需將 application_id 作為路徑參數傳入，並上傳文件。上傳的文件會被存儲在 S3 中。
+
+4. 系統管理員即可進行審核，審核通過後，系統會自動將使用者的帳號狀態更新為「已驗證」，並發送通知給使用者。

--- a/src/therapist/router.py
+++ b/src/therapist/router.py
@@ -1,46 +1,40 @@
 from typing import List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from src.auth.models import User
 from src.therapist.schemas import (
-    TherapistProfileCreate,
     TherapistProfileUpdate,
     TherapistProfileResponse,
-    TherapistApplicationRequest,
     TherapistClientCreate,
     TherapistClientResponse,
-    UserWithProfileResponse
+    UserWithProfileResponse,
+    TherapistRegistrationResponse,
+    TherapistRegisterRequest
 )
 from src.therapist.services import therapist_service
-from src.auth.services.permission_service import get_current_user, require_permission, Permission
+from src.auth.services.permission_service import require_permission, Permission
 from src.shared.database.database import get_session
 
 router = APIRouter(prefix="/therapist", tags=["therapist"])
 
-@router.post(
-    "/apply", 
-    response_model=TherapistProfileResponse,
-    summary="申請成為治療師並提交個人檔案",
-    description="""
-    使用者提交治療師申請，包含個人簡介、學歷、資歷、專注領域等文字資訊。
-    此端點會建立或更新治療師的個人檔案，並在內部啟動或連結一個驗證申請流程。
-    文件上傳（如證書、身分證）需透過 `/verification/therapist-applications/{application_id}/documents/` 端點進行。
-    """
-)
-async def apply_to_be_therapist(
-    application_data: TherapistApplicationRequest,
-    current_user: User = Depends(get_current_user),
-    session: Session = Depends(get_session)
+
+@router.post("/register", 
+             response_model=TherapistRegistrationResponse, 
+             status_code=status.HTTP_201_CREATED, 
+             summary="註冊新治療師帳號",
+             description="""
+             提供基本資料和專業檔案來一次性註冊新的治療師帳號。
+             此操作會建立使用者、治療師檔案和一個待處理的驗證申請。
+             """)
+async def register_therapist(
+    request: TherapistRegisterRequest,
+    session: Session = Depends(get_session),
 ):
-    profile = await therapist_service.apply_to_be_therapist(
-        current_user.user_id, 
-        application_data,
-        session
-    )
-    return profile
+    return await therapist_service.register_new_therapist(session=session, request=request)
+
 
 @router.get(
     "/profile", 
@@ -55,33 +49,12 @@ async def get_my_therapist_profile(
     current_user: User = Depends(require_permission(Permission.VIEW_THERAPIST_PROFILE)),
     session: Session = Depends(get_session)
 ):
-    profile = therapist_service.get_therapist_profile(current_user.user_id, session)
+    profile = therapist_service.get_therapist_profile(session, current_user.user_id)
     if not profile:
         raise HTTPException(
             status_code=404,
             detail="治療師檔案不存在"
         )
-    return profile
-
-@router.post(
-    "/profile", 
-    response_model=TherapistProfileResponse,
-    summary="建立治療師檔案 (僅限治療師角色)",
-    description="""
-    為當前登入的使用者建立治療師檔案。此操作僅限於已具備治療師角色的使用者。
-    如果使用者尚未有治療師檔案，則會建立一個新的檔案。
-    """
-)
-async def create_therapist_profile(
-    profile_data: TherapistProfileCreate,
-    current_user: User = Depends(require_permission(Permission.MANAGE_THERAPIST_PROFILE)),
-    session: Session = Depends(get_session)
-):
-    profile = therapist_service.create_therapist_profile(
-        current_user.user_id, 
-        profile_data,
-        session
-    )
     return profile
 
 @router.put(
@@ -99,9 +72,9 @@ async def update_therapist_profile(
     session: Session = Depends(get_session)
 ):
     profile = therapist_service.update_therapist_profile(
+        session, 
         current_user.user_id, 
-        profile_data,
-        session
+        profile_data
     )
     return profile
 
@@ -117,7 +90,7 @@ async def delete_therapist_profile(
     current_user: User = Depends(require_permission(Permission.MANAGE_THERAPIST_PROFILE)),
     session: Session = Depends(get_session)
 ):
-    success = therapist_service.delete_therapist_profile(current_user.user_id, session)
+    success = therapist_service.delete_therapist_profile(session, current_user.user_id)
     return {"message": "治療師檔案已刪除", "success": success}
 
 @router.get(
@@ -134,7 +107,7 @@ async def get_therapist_profile_by_id(
     current_user: User = Depends(require_permission(Permission.VIEW_THERAPIST_PROFILE)),
     session: Session = Depends(get_session)
 ):
-    profile = therapist_service.get_therapist_profile(user_id, session)
+    profile = therapist_service.get_therapist_profile(session, user_id)
     if not profile:
         raise HTTPException(
             status_code=404,
@@ -158,9 +131,9 @@ async def assign_client_to_therapist(
     session: Session = Depends(get_session)
 ):
     assignment = therapist_service.assign_client_to_therapist(
+        session,
         therapist_id,
-        assignment_data.client_id,
-        session=session
+        assignment_data.client_id
     )
     return assignment
 
@@ -176,7 +149,7 @@ async def get_my_clients(
     current_user: User = Depends(require_permission(Permission.VIEW_ASSIGNED_CLIENTS)),
     session: Session = Depends(get_session)
 ):
-    clients = therapist_service.get_therapist_clients(current_user.user_id, session)
+    clients = therapist_service.get_therapist_clients(session, current_user.user_id)
     return clients
 
 @router.delete(
@@ -192,9 +165,9 @@ async def unassign_client(
     session: Session = Depends(get_session)
 ):
     success = therapist_service.unassign_client_from_therapist(
+        session,
         current_user.user_id,
-        client_id,
-        session=session
+        client_id
     )
     return {"message": "客戶指派已取消", "success": success}
 
@@ -211,10 +184,9 @@ async def get_all_therapists(
     session: Session = Depends(get_session)
 ):
     therapists = therapist_service.get_all_therapists(session)
-    # 載入治療師檔案
     result = []
     for therapist in therapists:
-        profile = therapist_service.get_therapist_profile(therapist.user_id, session)
+        profile = therapist_service.get_therapist_profile(session, therapist.user_id)
         therapist_data = {
             "user_id": therapist.user_id,
             "account_id": therapist.account_id,

--- a/src/therapist/services/therapist_service.py
+++ b/src/therapist/services/therapist_service.py
@@ -10,327 +10,324 @@ from src.therapist.models import TherapistProfile, TherapistClient
 from src.therapist.schemas import (
     TherapistProfileCreate, 
     TherapistProfileUpdate, 
-    TherapistProfileResponse,
     TherapistApplicationRequest
 )
 from src.verification import services as verification_services # 導入 verification 服務
 
 
-class TherapistService:
-    """治療師相關服務"""
-    
-    def __init__(self, session: Session):
-        self.session = session
-    
-    def create_therapist_profile(
-        self, 
-        user_id: UUID, 
-        profile_data: TherapistProfileCreate
-    ) -> TherapistProfile:
-        """建立治療師檔案"""
-        
-        # 驗證用戶存在且為治療師角色
-        user = self.session.exec(
-            select(User).where(User.user_id == user_id)
-        ).first()
-        
-        if not user:
-            raise HTTPException(
-                status_code=404,
-                detail="用戶不存在"
-            )
-        
-        if user.role != UserRole.THERAPIST:
-            raise HTTPException(
-                status_code=400,
-                detail="只有治療師角色才能建立治療師檔案"
-            )
-        
-        # 檢查是否已有檔案
-        existing_profile = self.session.exec(
-            select(TherapistProfile).where(TherapistProfile.user_id == user_id)
-        ).first()
-        
-        if existing_profile:
-            raise HTTPException(
-                status_code=400,
-                detail="該用戶已有治療師檔案"
-            )
-        
-        # 檢查執照號碼是否重複
-        existing_license = self.session.exec(
-            select(TherapistProfile).where(
-                TherapistProfile.license_number == profile_data.license_number
-            )
-        ).first()
-        
-        if existing_license:
-            raise HTTPException(
-                status_code=400,
-                detail="執照號碼已存在"
-            )
-        
-        # 建立檔案
-        profile = TherapistProfile(
-            user_id=user_id,
-            license_number=profile_data.license_number,
-            specialization=profile_data.specialization,
-            bio=profile_data.bio,
-            years_experience=profile_data.years_experience,
-            education=profile_data.education,
-            created_at=datetime.now(),
-            updated_at=datetime.now()
-        )
-        
-        self.session.add(profile)
-        self.session.commit()
-        self.session.refresh(profile)
-        
-        return profile
-    
-    def get_therapist_profile(self, user_id: UUID) -> Optional[TherapistProfile]:
-        """取得治療師檔案"""
-        return self.session.exec(
-            select(TherapistProfile).where(TherapistProfile.user_id == user_id)
-        ).first()
-    
-    def update_therapist_profile(
-        self, 
-        user_id: UUID, 
-        profile_data: TherapistProfileUpdate
-    ) -> TherapistProfile:
-        """更新治療師檔案"""
-        
-        profile = self.get_therapist_profile(user_id)
-        if not profile:
-            raise HTTPException(
-                status_code=404,
-                detail="治療師檔案不存在"
-            )
-        
-        # 檢查執照號碼是否重複（排除自己）
-        if profile_data.license_number:
-            existing_license = self.session.exec(
-                select(TherapistProfile).where(
-                    TherapistProfile.license_number == profile_data.license_number,
-                    TherapistProfile.user_id != user_id
-                )
-            ).first()
-            
-            if existing_license:
-                raise HTTPException(
-                    status_code=400,
-                    detail="執照號碼已存在"
-                )
-        
-        # 更新檔案
-        update_data = profile_data.model_dump(exclude_unset=True)
-        for field, value in update_data.items():
-            setattr(profile, field, value)
-        
-        profile.updated_at = datetime.now()
-        
-        self.session.add(profile)
-        self.session.commit()
-        self.session.refresh(profile)
-        
-        return profile
-    
-    def delete_therapist_profile(self, user_id: UUID) -> bool:
-        """刪除治療師檔案"""
-        
-        profile = self.get_therapist_profile(user_id)
-        if not profile:
-            raise HTTPException(
-                status_code=404,
-                detail="治療師檔案不存在"
-            )
-        
-        self.session.delete(profile)
-        self.session.commit()
-        
-        return True
-    
-    def assign_client_to_therapist(
-        self, 
-        therapist_id: UUID, 
-        client_id: UUID,
-        notes: Optional[str] = None
-    ) -> TherapistClient:
-        """指派客戶給治療師"""
-        
-        # 驗證治療師
-        therapist = self.session.exec(
-            select(User).where(
-                User.user_id == therapist_id,
-                User.role == UserRole.THERAPIST
-            )
-        ).first()
-        
-        if not therapist:
-            raise HTTPException(
-                status_code=404,
-                detail="治療師不存在"
-            )
-        
-        # 驗證客戶
-        client = self.session.exec(
-            select(User).where(
-                User.user_id == client_id,
-                User.role == UserRole.CLIENT
-            )
-        ).first()
-        
-        if not client:
-            raise HTTPException(
-                status_code=404,
-                detail="客戶不存在"
-            )
-        
-        # 檢查是否已指派
-        existing_assignment = self.session.exec(
-            select(TherapistClient).where(
-                TherapistClient.therapist_id == therapist_id,
-                TherapistClient.client_id == client_id,
-                TherapistClient.is_active == True
-            )
-        ).first()
-        
-        if existing_assignment:
-            raise HTTPException(
-                status_code=400,
-                detail="該客戶已指派給此治療師"
-            )
-        
-        # 建立指派關係
-        assignment = TherapistClient(
-            therapist_id=therapist_id,
-            client_id=client_id,
-            assigned_date=datetime.now(),
-            is_active=True,
-            notes=notes,
-            created_at=datetime.now(),
-            updated_at=datetime.now()
-        )
-        
-        self.session.add(assignment)
-        self.session.commit()
-        self.session.refresh(assignment)
-        
-        return assignment
-    
-    def get_therapist_clients(self, therapist_id: UUID) -> List[TherapistClient]:
-        """取得治療師的客戶列表"""
-        return self.session.exec(
-            select(TherapistClient).where(
-                TherapistClient.therapist_id == therapist_id,
-                TherapistClient.is_active == True
-            )
-        ).all()
-    
-    def get_client_therapists(self, client_id: UUID) -> List[TherapistClient]:
-        """取得客戶的治療師列表"""
-        return self.session.exec(
-            select(TherapistClient).where(
-                TherapistClient.client_id == client_id,
-                TherapistClient.is_active == True
-            )
-        ).all()
-    
-    def unassign_client_from_therapist(
-        self, 
-        therapist_id: UUID, 
-        client_id: UUID
-    ) -> bool:
-        """取消客戶與治療師的指派關係"""
-        
-        assignment = self.session.exec(
-            select(TherapistClient).where(
-                TherapistClient.therapist_id == therapist_id,
-                TherapistClient.client_id == client_id,
-                TherapistClient.is_active == True
-            )
-        ).first()
-        
-        if not assignment:
-            raise HTTPException(
-                status_code=404,
-                detail="指派關係不存在"
-            )
-        
-        assignment.is_active = False
-        assignment.updated_at = datetime.now()
-        
-        self.session.add(assignment)
-        self.session.commit()
-        
-        return True
-    
-    async def apply_to_be_therapist(
-        self, 
-        user_id: UUID, 
-        application_data: TherapistApplicationRequest
-    ) -> TherapistProfile:
-        """申請成為治療師（建立檔案但不改變角色）"""
-        
-        # 驗證用戶存在
-        user = self.session.exec(
-            select(User).where(User.user_id == user_id)
-        ).first()
-        
-        if not user:
-            raise HTTPException(
-                status_code=404,
-                detail="用戶不存在"
-            )
-        
-        # 檢查是否已有檔案
-        existing_profile = self.get_therapist_profile(user_id)
-        if existing_profile:
-            raise HTTPException(
-                status_code=400,
-                detail="該用戶已有治療師檔案"
-            )
-        
-        # 檢查執照號碼是否重複
-        existing_license = self.session.exec(
-            select(TherapistProfile).where(
-                TherapistProfile.license_number == application_data.license_number
-            )
-        ).first()
-        
-        if existing_license:
-            raise HTTPException(
-                status_code=400,
-                detail="執照號碼已存在"
-            )
-        
-        # 檢查或建立驗證申請
-        verification_application = await verification_services.get_latest_application_for_user(user_id, self.session)
-        if not verification_application:
-            verification_application = await verification_services.create_application(user, self.session)
+# therapist_service.py - 函數式服務
 
-        # 建立治療師檔案（但不改變用戶角色，需管理員審核）
-        profile = TherapistProfile(
-            user_id=user_id,
-            license_number=application_data.license_number,
-            specialization=application_data.specialization,
-            bio=application_data.bio,
-            years_experience=application_data.years_experience,
-            education=application_data.education,
-            verification_application_id=verification_application.id, # 連結到驗證申請
-            created_at=datetime.now(),
-            updated_at=datetime.now()
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from src.auth.models import User, UserRole
+from src.therapist.models import TherapistProfile, TherapistClient
+from src.therapist.schemas import (
+    TherapistProfileCreate, 
+    TherapistProfileUpdate, 
+    TherapistApplicationRequest
+)
+from src.verification import services as verification_services
+
+def create_therapist_profile(
+    user_id: UUID, 
+    profile_data: TherapistProfileCreate,
+    session: Session
+) -> TherapistProfile:
+    """建立治療師檔案"""
+    user = session.exec(
+        select(User).where(User.user_id == user_id)
+    ).first()
+    if not user:
+        raise HTTPException(
+            status_code=404,
+            detail="用戶不存在"
         )
-        
-        self.session.add(profile)
-        self.session.commit()
-        self.session.refresh(profile)
-        
-        return profile
+    if user.role != UserRole.THERAPIST:
+        raise HTTPException(
+            status_code=400,
+            detail="只有治療師角色才能建立治療師檔案"
+        )
+    existing_profile = session.exec(
+        select(TherapistProfile).where(TherapistProfile.user_id == user_id)
+    ).first()
+    if existing_profile:
+        raise HTTPException(
+            status_code=400,
+            detail="該用戶已有治療師檔案"
+        )
+    existing_license = session.exec(
+        select(TherapistProfile).where(
+            TherapistProfile.license_number == profile_data.license_number
+        )
+    ).first()
+    if existing_license:
+        raise HTTPException(
+            status_code=400,
+            detail="執照號碼已存在"
+        )
+    profile = TherapistProfile(
+        user_id=user_id,
+        license_number=profile_data.license_number,
+        specialization=profile_data.specialization,
+        bio=profile_data.bio,
+        years_experience=profile_data.years_experience,
+        education=profile_data.education,
+        created_at=datetime.now(),
+        updated_at=datetime.now()
+    )
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+def get_therapist_profile(session: Session, user_id: UUID) -> Optional[TherapistProfile]:
+    """取得治療師檔案"""
+    return session.exec(
+            select(TherapistProfile).where(TherapistProfile.user_id == user_id)
+        ).first()
     
-    def get_all_therapists(self) -> List[User]:
-        """取得所有治療師"""
-        return self.session.exec(
-            select(User).where(User.role == UserRole.THERAPIST)
-        ).all()
+def update_therapist_profile(
+    self, 
+    user_id: UUID, 
+    profile_data: TherapistProfileUpdate
+) -> TherapistProfile:
+    """更新治療師檔案"""
+    
+    profile = self.get_therapist_profile(user_id)
+    if not profile:
+        raise HTTPException(
+            status_code=404,
+            detail="治療師檔案不存在"
+        )
+    
+    # 檢查執照號碼是否重複（排除自己）
+    if profile_data.license_number:
+        existing_license = self.session.exec(
+            select(TherapistProfile).where(
+                TherapistProfile.license_number == profile_data.license_number,
+                TherapistProfile.user_id != user_id
+            )
+        ).first()
+        
+        if existing_license:
+            raise HTTPException(
+                status_code=400,
+                detail="執照號碼已存在"
+            )
+    
+    # 更新檔案
+    update_data = profile_data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(profile, field, value)
+    
+    profile.updated_at = datetime.now()
+    
+    self.session.add(profile)
+    self.session.commit()
+    self.session.refresh(profile)
+    
+    return profile
+
+def delete_therapist_profile(self, user_id: UUID) -> bool:
+    """刪除治療師檔案"""
+    
+    profile = self.get_therapist_profile(user_id)
+    if not profile:
+        raise HTTPException(
+            status_code=404,
+            detail="治療師檔案不存在"
+        )
+    
+    self.session.delete(profile)
+    self.session.commit()
+    
+    return True
+
+def assign_client_to_therapist(
+    self, 
+    therapist_id: UUID, 
+    client_id: UUID,
+    notes: Optional[str] = None
+) -> TherapistClient:
+    """指派客戶給治療師"""
+    
+    # 驗證治療師
+    therapist = self.session.exec(
+        select(User).where(
+            User.user_id == therapist_id,
+            User.role == UserRole.THERAPIST
+        )
+    ).first()
+    
+    if not therapist:
+        raise HTTPException(
+            status_code=404,
+            detail="治療師不存在"
+        )
+    
+    # 驗證客戶
+    client = self.session.exec(
+        select(User).where(
+            User.user_id == client_id,
+            User.role == UserRole.CLIENT
+        )
+    ).first()
+    
+    if not client:
+        raise HTTPException(
+            status_code=404,
+            detail="客戶不存在"
+        )
+    
+    # 檢查是否已指派
+    existing_assignment = self.session.exec(
+        select(TherapistClient).where(
+            TherapistClient.therapist_id == therapist_id,
+            TherapistClient.client_id == client_id,
+            TherapistClient.is_active == True
+        )
+    ).first()
+    
+    if existing_assignment:
+        raise HTTPException(
+            status_code=400,
+            detail="該客戶已指派給此治療師"
+        )
+    
+    # 建立指派關係
+    assignment = TherapistClient(
+        therapist_id=therapist_id,
+        client_id=client_id,
+        assigned_date=datetime.now(),
+        is_active=True,
+        notes=notes,
+        created_at=datetime.now(),
+        updated_at=datetime.now()
+    )
+    
+    self.session.add(assignment)
+    self.session.commit()
+    self.session.refresh(assignment)
+    
+    return assignment
+
+def get_therapist_clients(self, therapist_id: UUID) -> List[TherapistClient]:
+    """取得治療師的客戶列表"""
+    return self.session.exec(
+        select(TherapistClient).where(
+            TherapistClient.therapist_id == therapist_id,
+            TherapistClient.is_active == True
+        )
+    ).all()
+
+def get_client_therapists(self, client_id: UUID) -> List[TherapistClient]:
+    """取得客戶的治療師列表"""
+    return self.session.exec(
+        select(TherapistClient).where(
+            TherapistClient.client_id == client_id,
+            TherapistClient.is_active == True
+        )
+    ).all()
+
+def unassign_client_from_therapist(
+    self, 
+    therapist_id: UUID, 
+    client_id: UUID
+) -> bool:
+    """取消客戶與治療師的指派關係"""
+    
+    assignment = self.session.exec(
+        select(TherapistClient).where(
+            TherapistClient.therapist_id == therapist_id,
+            TherapistClient.client_id == client_id,
+            TherapistClient.is_active == True
+        )
+    ).first()
+    
+    if not assignment:
+        raise HTTPException(
+            status_code=404,
+            detail="指派關係不存在"
+        )
+    
+    assignment.is_active = False
+    assignment.updated_at = datetime.now()
+    
+    self.session.add(assignment)
+    self.session.commit()
+    
+    return True
+
+async def apply_to_be_therapist(
+    self, 
+    user_id: UUID, 
+    application_data: TherapistApplicationRequest
+) -> TherapistProfile:
+    """申請成為治療師（建立檔案但不改變角色）"""
+    
+    # 驗證用戶存在
+    user = self.session.exec(
+        select(User).where(User.user_id == user_id)
+    ).first()
+    
+    if not user:
+        raise HTTPException(
+            status_code=404,
+            detail="用戶不存在"
+        )
+    
+    # 檢查是否已有檔案
+    existing_profile = self.get_therapist_profile(user_id)
+    if existing_profile:
+        raise HTTPException(
+            status_code=400,
+            detail="該用戶已有治療師檔案"
+        )
+    
+    # 檢查執照號碼是否重複
+    existing_license = self.session.exec(
+        select(TherapistProfile).where(
+            TherapistProfile.license_number == application_data.license_number
+        )
+    ).first()
+    
+    if existing_license:
+        raise HTTPException(
+            status_code=400,
+            detail="執照號碼已存在"
+        )
+    
+    # 檢查或建立驗證申請
+    verification_application = await verification_services.get_latest_application_for_user(user_id, self.session)
+    if not verification_application:
+        verification_application = await verification_services.create_application(user, self.session)
+
+    # 建立治療師檔案（但不改變用戶角色，需管理員審核）
+    profile = TherapistProfile(
+        user_id=user_id,
+        license_number=application_data.license_number,
+        specialization=application_data.specialization,
+        bio=application_data.bio,
+        years_experience=application_data.years_experience,
+        education=application_data.education,
+        verification_application_id=verification_application.id, # 連結到驗證申請
+        created_at=datetime.now(),
+        updated_at=datetime.now()
+    )
+    
+    self.session.add(profile)
+    self.session.commit()
+    self.session.refresh(profile)
+    
+    return profile
+
+def get_all_therapists(self) -> List[User]:
+    """取得所有治療師"""
+    return self.session.exec(
+        select(User).where(User.role == UserRole.THERAPIST)
+    ).all()

--- a/src/therapist/services/therapist_service.py
+++ b/src/therapist/services/therapist_service.py
@@ -6,200 +6,167 @@ from fastapi import HTTPException
 from sqlmodel import Session, select
 
 from src.auth.models import User, UserRole
+from src.auth.services.account_service import _create_account_and_user
 from src.therapist.models import TherapistProfile, TherapistClient
 from src.therapist.schemas import (
     TherapistProfileCreate, 
     TherapistProfileUpdate, 
-    TherapistApplicationRequest
+    TherapistRegisterRequest,
+    TherapistRegistrationResponse,
+    TherapistProfileData
 )
-from src.verification import services as verification_services # 導入 verification 服務
-
-
-# therapist_service.py - 函數式服務
-
-from datetime import datetime
-from typing import List, Optional
-from uuid import UUID
-
-from fastapi import HTTPException
-from sqlmodel import Session, select
-
-from src.auth.models import User, UserRole
-from src.therapist.models import TherapistProfile, TherapistClient
-from src.therapist.schemas import (
-    TherapistProfileCreate, 
-    TherapistProfileUpdate, 
-    TherapistApplicationRequest
-)
+from src.verification.models import TherapistApplication, ApplicationStatus
 from src.verification import services as verification_services
 
+async def register_new_therapist(session: Session, request: TherapistRegisterRequest) -> TherapistRegistrationResponse:
+    """Registers a new therapist in a single step, creating user, profile, and application."""
+    # Check for existing license number first to fail fast
+    if session.exec(select(TherapistProfile).where(TherapistProfile.license_number == request.license_number)).first():
+        raise HTTPException(
+            status_code=400,
+            detail="License number already registered"
+        )
+
+    try:
+        # 1. Create Account and User with 'CLIENT' role initially for safety
+        new_user = _create_account_and_user(
+            session=session,
+            email=request.email,
+            password=request.password,
+            name=request.name,
+            gender=request.gender.value,
+            age=request.age,
+            role=UserRole.CLIENT, # Start as client, promote upon approval
+            is_verified=True  # Mark email as verified since there is no email verification step
+        )
+
+        # 2. Create a verification application
+        application = TherapistApplication(
+            user_id=new_user.user_id,
+            status=ApplicationStatus.PENDING
+        )
+        session.add(application)
+        session.flush()
+
+        # 3. Create the therapist profile with all data provided
+        profile = TherapistProfile(
+            user_id=new_user.user_id,
+            verification_application_id=application.id,
+            license_number=request.license_number,
+            specialization=request.specialization,
+            bio=request.bio,
+            years_experience=request.years_experience,
+            education=request.education
+        )
+        session.add(profile)
+        session.flush()
+
+        session.commit()
+        
+        return TherapistRegistrationResponse(
+            user_id=new_user.user_id,
+            verification_application_id=application.id
+        )
+    except HTTPException as http_exc:
+        session.rollback()
+        raise http_exc
+    except Exception as e:
+        session.rollback()
+        # Check if the error is from the database unique constraint on email
+        if 'unique constraint' in str(e).lower() and 'accounts_email_key' in str(e).lower():
+             raise HTTPException(
+                status_code=400,
+                detail="Email already registered"
+            )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to register therapist: {str(e)}"
+        )
+
 def create_therapist_profile(
+    session: Session, 
     user_id: UUID, 
-    profile_data: TherapistProfileCreate,
-    session: Session
+    profile_data: TherapistProfileCreate
 ) -> TherapistProfile:
-    """建立治療師檔案"""
-    user = session.exec(
-        select(User).where(User.user_id == user_id)
-    ).first()
+    user = session.exec(select(User).where(User.user_id == user_id)).first()
     if not user:
-        raise HTTPException(
-            status_code=404,
-            detail="用戶不存在"
-        )
+        raise HTTPException(status_code=404, detail="用戶不存在")
     if user.role != UserRole.THERAPIST:
-        raise HTTPException(
-            status_code=400,
-            detail="只有治療師角色才能建立治療師檔案"
-        )
-    existing_profile = session.exec(
-        select(TherapistProfile).where(TherapistProfile.user_id == user_id)
-    ).first()
+        raise HTTPException(status_code=400, detail="只有治療師角色才能建立治療師檔案")
+    
+    existing_profile = get_therapist_profile(session, user_id)
     if existing_profile:
-        raise HTTPException(
-            status_code=400,
-            detail="該用戶已有治療師檔案"
-        )
-    existing_license = session.exec(
-        select(TherapistProfile).where(
-            TherapistProfile.license_number == profile_data.license_number
-        )
-    ).first()
-    if existing_license:
-        raise HTTPException(
-            status_code=400,
-            detail="執照號碼已存在"
-        )
-    profile = TherapistProfile(
-        user_id=user_id,
-        license_number=profile_data.license_number,
-        specialization=profile_data.specialization,
-        bio=profile_data.bio,
-        years_experience=profile_data.years_experience,
-        education=profile_data.education,
-        created_at=datetime.now(),
-        updated_at=datetime.now()
-    )
+        raise HTTPException(status_code=400, detail="該用戶已有治療師檔案")
+
+    if profile_data.license_number:
+        existing_license = session.exec(select(TherapistProfile).where(TherapistProfile.license_number == profile_data.license_number)).first()
+        if existing_license:
+            raise HTTPException(status_code=400, detail="執照號碼已存在")
+
+    profile = TherapistProfile(**profile_data.model_dump(), user_id=user_id)
     session.add(profile)
     session.commit()
     session.refresh(profile)
     return profile
 
 def get_therapist_profile(session: Session, user_id: UUID) -> Optional[TherapistProfile]:
-    """取得治療師檔案"""
-    return session.exec(
-            select(TherapistProfile).where(TherapistProfile.user_id == user_id)
-        ).first()
-    
+    return session.exec(select(TherapistProfile).where(TherapistProfile.user_id == user_id)).first()
+
 def update_therapist_profile(
-    self, 
+    session: Session, 
     user_id: UUID, 
     profile_data: TherapistProfileUpdate
 ) -> TherapistProfile:
-    """更新治療師檔案"""
-    
-    profile = self.get_therapist_profile(user_id)
+    profile = get_therapist_profile(session, user_id)
     if not profile:
-        raise HTTPException(
-            status_code=404,
-            detail="治療師檔案不存在"
-        )
-    
-    # 檢查執照號碼是否重複（排除自己）
+        raise HTTPException(status_code=404, detail="治療師檔案不存在")
+
     if profile_data.license_number:
-        existing_license = self.session.exec(
+        existing_license = session.exec(
             select(TherapistProfile).where(
                 TherapistProfile.license_number == profile_data.license_number,
                 TherapistProfile.user_id != user_id
             )
         ).first()
-        
         if existing_license:
-            raise HTTPException(
-                status_code=400,
-                detail="執照號碼已存在"
-            )
-    
-    # 更新檔案
+            raise HTTPException(status_code=400, detail="執照號碼已存在")
+
     update_data = profile_data.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(profile, field, value)
     
     profile.updated_at = datetime.now()
-    
-    self.session.add(profile)
-    self.session.commit()
-    self.session.refresh(profile)
-    
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
     return profile
 
-def delete_therapist_profile(self, user_id: UUID) -> bool:
-    """刪除治療師檔案"""
-    
-    profile = self.get_therapist_profile(user_id)
+def delete_therapist_profile(session: Session, user_id: UUID) -> bool:
+    profile = get_therapist_profile(session, user_id)
     if not profile:
-        raise HTTPException(
-            status_code=404,
-            detail="治療師檔案不存在"
-        )
-    
-    self.session.delete(profile)
-    self.session.commit()
-    
+        raise HTTPException(status_code=404, detail="治療師檔案不存在")
+    session.delete(profile)
+    session.commit()
     return True
 
 def assign_client_to_therapist(
-    self, 
+    session: Session,
     therapist_id: UUID, 
     client_id: UUID,
     notes: Optional[str] = None
 ) -> TherapistClient:
-    """指派客戶給治療師"""
-    
-    # 驗證治療師
-    therapist = self.session.exec(
-        select(User).where(
-            User.user_id == therapist_id,
-            User.role == UserRole.THERAPIST
-        )
-    ).first()
-    
+    therapist = session.exec(select(User).where(User.user_id == therapist_id, User.role == UserRole.THERAPIST)).first()
     if not therapist:
-        raise HTTPException(
-            status_code=404,
-            detail="治療師不存在"
-        )
+        raise HTTPException(status_code=404, detail="治療師不存在")
     
-    # 驗證客戶
-    client = self.session.exec(
-        select(User).where(
-            User.user_id == client_id,
-            User.role == UserRole.CLIENT
-        )
-    ).first()
-    
+    client = session.exec(select(User).where(User.user_id == client_id, User.role == UserRole.CLIENT)).first()
     if not client:
-        raise HTTPException(
-            status_code=404,
-            detail="客戶不存在"
-        )
+        raise HTTPException(status_code=404, detail="客戶不存在")
     
-    # 檢查是否已指派
-    existing_assignment = self.session.exec(
-        select(TherapistClient).where(
-            TherapistClient.therapist_id == therapist_id,
-            TherapistClient.client_id == client_id,
-            TherapistClient.is_active == True
-        )
-    ).first()
-    
+    existing_assignment = session.exec(select(TherapistClient).where(TherapistClient.therapist_id == therapist_id, TherapistClient.client_id == client_id, TherapistClient.is_active == True)).first()
     if existing_assignment:
-        raise HTTPException(
-            status_code=400,
-            detail="該客戶已指派給此治療師"
-        )
+        raise HTTPException(status_code=400, detail="該客戶已指派給此治療師")
     
-    # 建立指派關係
     assignment = TherapistClient(
         therapist_id=therapist_id,
         client_id=client_id,
@@ -209,105 +176,53 @@ def assign_client_to_therapist(
         created_at=datetime.now(),
         updated_at=datetime.now()
     )
-    
-    self.session.add(assignment)
-    self.session.commit()
-    self.session.refresh(assignment)
-    
+    session.add(assignment)
+    session.commit()
+    session.refresh(assignment)
     return assignment
 
-def get_therapist_clients(self, therapist_id: UUID) -> List[TherapistClient]:
-    """取得治療師的客戶列表"""
-    return self.session.exec(
-        select(TherapistClient).where(
-            TherapistClient.therapist_id == therapist_id,
-            TherapistClient.is_active == True
-        )
-    ).all()
+def get_therapist_clients(session: Session, therapist_id: UUID) -> List[TherapistClient]:
+    return session.exec(select(TherapistClient).where(TherapistClient.therapist_id == therapist_id, TherapistClient.is_active == True)).all()
 
-def get_client_therapists(self, client_id: UUID) -> List[TherapistClient]:
-    """取得客戶的治療師列表"""
-    return self.session.exec(
-        select(TherapistClient).where(
-            TherapistClient.client_id == client_id,
-            TherapistClient.is_active == True
-        )
-    ).all()
+def get_client_therapists(session: Session, client_id: UUID) -> List[TherapistClient]:
+    return session.exec(select(TherapistClient).where(TherapistClient.client_id == client_id, TherapistClient.is_active == True)).all()
 
 def unassign_client_from_therapist(
-    self, 
+    session: Session, 
     therapist_id: UUID, 
     client_id: UUID
 ) -> bool:
-    """取消客戶與治療師的指派關係"""
-    
-    assignment = self.session.exec(
-        select(TherapistClient).where(
-            TherapistClient.therapist_id == therapist_id,
-            TherapistClient.client_id == client_id,
-            TherapistClient.is_active == True
-        )
-    ).first()
-    
+    assignment = session.exec(select(TherapistClient).where(TherapistClient.therapist_id == therapist_id, TherapistClient.client_id == client_id, TherapistClient.is_active == True)).first()
     if not assignment:
-        raise HTTPException(
-            status_code=404,
-            detail="指派關係不存在"
-        )
+        raise HTTPException(status_code=404, detail="指派關係不存在")
     
     assignment.is_active = False
     assignment.updated_at = datetime.now()
-    
-    self.session.add(assignment)
-    self.session.commit()
-    
+    session.add(assignment)
+    session.commit()
     return True
 
 async def apply_to_be_therapist(
-    self, 
+    session: Session,
     user_id: UUID, 
-    application_data: TherapistApplicationRequest
+    application_data: TherapistProfileData
 ) -> TherapistProfile:
-    """申請成為治療師（建立檔案但不改變角色）"""
-    
-    # 驗證用戶存在
-    user = self.session.exec(
-        select(User).where(User.user_id == user_id)
-    ).first()
-    
+    user = session.exec(select(User).where(User.user_id == user_id)).first()
     if not user:
-        raise HTTPException(
-            status_code=404,
-            detail="用戶不存在"
-        )
+        raise HTTPException(status_code=404, detail="用戶不存在")
     
-    # 檢查是否已有檔案
-    existing_profile = self.get_therapist_profile(user_id)
+    existing_profile = get_therapist_profile(session, user_id)
     if existing_profile:
-        raise HTTPException(
-            status_code=400,
-            detail="該用戶已有治療師檔案"
-        )
+        raise HTTPException(status_code=400, detail="該用戶已有治療師檔案")
     
-    # 檢查執照號碼是否重複
-    existing_license = self.session.exec(
-        select(TherapistProfile).where(
-            TherapistProfile.license_number == application_data.license_number
-        )
-    ).first()
-    
+    existing_license = session.exec(select(TherapistProfile).where(TherapistProfile.license_number == application_data.license_number)).first()
     if existing_license:
-        raise HTTPException(
-            status_code=400,
-            detail="執照號碼已存在"
-        )
+        raise HTTPException(status_code=400, detail="執照號碼已存在")
     
-    # 檢查或建立驗證申請
-    verification_application = await verification_services.get_latest_application_for_user(user_id, self.session)
+    verification_application = await verification_services.get_latest_application_for_user(user_id, session)
     if not verification_application:
-        verification_application = await verification_services.create_application(user, self.session)
+        verification_application = await verification_services.create_application(user, session)
 
-    # 建立治療師檔案（但不改變用戶角色，需管理員審核）
     profile = TherapistProfile(
         user_id=user_id,
         license_number=application_data.license_number,
@@ -315,19 +230,14 @@ async def apply_to_be_therapist(
         bio=application_data.bio,
         years_experience=application_data.years_experience,
         education=application_data.education,
-        verification_application_id=verification_application.id, # 連結到驗證申請
+        verification_application_id=verification_application.id,
         created_at=datetime.now(),
         updated_at=datetime.now()
     )
-    
-    self.session.add(profile)
-    self.session.commit()
-    self.session.refresh(profile)
-    
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
     return profile
 
-def get_all_therapists(self) -> List[User]:
-    """取得所有治療師"""
-    return self.session.exec(
-        select(User).where(User.role == UserRole.THERAPIST)
-    ).all()
+def get_all_therapists(session: Session) -> List[User]:
+    return session.exec(select(User).where(User.role == UserRole.THERAPIST)).all()

--- a/src/verification/router.py
+++ b/src/verification/router.py
@@ -54,15 +54,12 @@ async def upload_document(
     application_id: uuid.UUID,
     document_type: DocumentType = Form(...),
     file: UploadFile = File(...),
-    current_user: User = Depends(get_current_user),
     db_session: Session = Depends(get_session)
 ):
-    """為指定的申請上傳文件（例如身分證、證書等）。"""
+    """為指定的申請上傳文件（例如身分證、證書等）。此 API 無需登入。"""
     application = await services.get_application_by_id(application_id, db_session)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="找不到指定的申請")
-    if application.user_id != current_user.user_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="使用者無權操作此申請")
     
     return await services.upload_verification_document(application, document_type, file, db_session)
 


### PR DESCRIPTION
- 新增 TherapistRegisterRequest 與 TherapistRegistrationResponse，簡化治療師註冊流程，支援一次性建立帳號、個人檔案與驗證申請
- therapist_service.py 新增 register_new_therapist，整合註冊、檔案建立與驗證申請
- therapist/router.py 新增 /therapist/register 端點，移除 apply/profile 等舊 API，統一註冊流程
- schemas.py 移除 TherapistApplicationRequest，改為 TherapistProfileData，並調整相關欄位
- account_service.py 將帳號與使用者建立邏輯抽出為 _create_account_and_user，提升重用性
- therapist_service.py、router.py、schemas.py、verification/router.py、verification/services.py 等多處同步調整參數、錯誤處理與依賴注入
- 文件上傳 API 移除登入驗證，並加強異常處理（504/503/500）